### PR TITLE
Fix auto update of yarn version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         run: docker exec -i db psql -U ${{ env.POSTGRES_USER }} < ./sql_scripts/init.sql
 
       # run tests
-      - run: yarn set version berry
       - run: yarn install
       - run: yarn lint
       - run: yarn test


### PR DESCRIPTION
## Purpose

The CI pipeline is non-deterministic.

## Proposed Change

Don't update yarn version when running the pipeline.

## Checklist

- [x] Remove `yarn set version berry`
